### PR TITLE
Height of tab name

### DIFF
--- a/Kalender2016.tex
+++ b/Kalender2016.tex
@@ -1,8 +1,9 @@
 \listfiles
-\documentclass[draft]{kalenderRN}
+\documentclass[landscape]{kalenderRN}
 
 %\renewcommand*\year{2018}
+%\noevents
 
 \begin{document}
-  \makeKalender[Termine]
+  \makeTeilkalender[Termine]{1}{8}
 \end{document} 

--- a/kalenderRN.cls
+++ b/kalenderRN.cls
@@ -136,7 +136,7 @@
           % Print month name
           \draw (0,0)node [shape=rectangle,minimum height=.53cm,%
             text width=4.4cm,fill=dark,text=white,draw=dark,text centered]{%
-              \textbf{\pgfcalendarmonthname{\pgfcalendarcurrentmonth}}};}{}%
+              \resizebox{!}{.225cm}{\textbf{\pgfcalendarmonthname{\pgfcalendarcurrentmonth}}}};}{}%
         \ifdate{workday}{%
           \tikzset{every day/.style={fill=white}}%
           \RN@periods}{}%


### PR DESCRIPTION
The tab with the name of the month was too high for April, August and September. The letters 'p' and 'g' caused these tabs to be calculated higher than the others. I added a scalebox with a matching y-scale value. It's been at bit trial and error, but I found a size big enough for the text to be considered normal size, small enough to hinder the tab from making itself to high.
